### PR TITLE
Django 1.8 fix broken deferred mail script

### DIFF
--- a/mailer/management/commands/retry_deferred.py
+++ b/mailer/management/commands/retry_deferred.py
@@ -14,7 +14,10 @@ class Command(NoArgsCommand):
             '1': logging.INFO,
             '2': logging.DEBUG,
         }
-        level = log_levels[options['verbosity']]
+        # in case of 1.4 compatibility, where a string would be passed in
+
+        verbosity = str(options['verbosity'])
+        level = log_levels[verbosity]
         logging.basicConfig(level=level, format="%(message)s")
         count = Message.objects.retry_deferred() # @@@ new_priority not yet supported
         logging.info("%s message(s) retried" % count)

--- a/mailer/tests.py
+++ b/mailer/tests.py
@@ -58,3 +58,11 @@ class MailerTestCase(TestCase):
     def test_view_smoke_test(self):
         r = self.client.get(reverse('mailer_report'))
         self.assertEqual(r.status_code, 302)
+
+
+class RetryDeferredCommandTestCase(TestCase):
+    def test_command_can_run(self):
+        args = []
+        opts = {}
+
+        management.call_command('retry_deferred', *args, **opts)


### PR DESCRIPTION
The deferred mail script doesn't work under 1.8 because it will convert numeric options to integers

```
Traceback (most recent call last):
  File "manage.py", line 15, in <module>
    execute_manager()
  File "manage.py", line 11, in execute_manager
    utility.execute()
  File "/home/policystat/env/lib/python2.7/site-packages/django/core/management/__init__.py", line 346, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/policystat/env/lib/python2.7/site-packages/django/core/management/base.py", line 394, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/policystat/env/lib/python2.7/site-packages/django/core/management/base.py", line 445, in execute
    output = self.handle(*args, **options)
  File "/home/policystat/env/lib/python2.7/site-packages/django/core/management/base.py", line 661, in handle
    return self.handle_noargs(**options)
  File "/home/policystat/env/lib/python2.7/site-packages/mailer/management/commands/retry_deferred.py", line 17, in handle_noargs
    level = log_levels[options['verbosity']]
KeyError: 1
```
